### PR TITLE
New(ish) postcode areas

### DIFF
--- a/data/postcodes.json
+++ b/data/postcodes.json
@@ -8139,6 +8139,17 @@
   "latitude": "51.52939", 
   "northings": "183000"
 },{
+  "town": "Queen Elizabeth Olympic Park", 
+  "country_string": "England", 
+  "eastings": "538350", 
+  "country": "ENG", 
+  "region": "Greater London", 
+  "longitude": "0.09248", 
+  "uk_region": "London", 
+  "postcode": "E20", 
+  "latitude": "51.54593", 
+  "northings": "184500"
+},{
   "town": "Poplar", 
   "country_string": "England", 
   "eastings": "537000", 
@@ -8535,7 +8546,7 @@
   "latitude": "51.51397", 
   "northings": "181200"
 },{
-  "town": "Edinburgh", 
+  "town": "Old Town", 
   "country_string": "Scotland", 
   "eastings": "325800", 
   "country": "SCT", 
@@ -8546,7 +8557,7 @@
   "latitude": "55.95243", 
   "northings": "673900"
 },{
-  "town": "Edinburgh", 
+  "town": "Morningside, Braid Hill and Swanston", 
   "country_string": "Scotland", 
   "eastings": "324400", 
   "country": "SCT", 
@@ -8557,7 +8568,7 @@
   "latitude": "55.92077", 
   "northings": "670400"
 },{
-  "town": "Juniper Green", 
+  "town": "Gorgie, Stenhouse and Sighthill", 
   "country_string": "Scotland", 
   "eastings": "322000", 
   "country": "SCT", 
@@ -8568,7 +8579,7 @@
   "latitude": "55.93387", 
   "northings": "671900"
 },{
-  "town": "Edinburgh", 
+  "town": "Murrayfield, Corstorphine and Gogar", 
   "country_string": "Scotland", 
   "eastings": "320600", 
   "country": "SCT", 
@@ -8579,7 +8590,7 @@
   "latitude": "55.94262", 
   "northings": "672900"
 },{
-  "town": "Juniper Green", 
+  "town": "Colinton and Oxgangs", 
   "country_string": "Scotland", 
   "eastings": "322400", 
   "country": "SCT", 
@@ -8590,7 +8601,7 @@
   "latitude": "55.90788", 
   "northings": "669000"
 },{
-  "town": "Juniper Green", 
+  "town": "Juniper Green, Currie and Balerno", 
   "country_string": "Scotland", 
   "eastings": "319800", 
   "country": "SCT", 
@@ -8601,7 +8612,7 @@
   "latitude": "55.90925", 
   "northings": "669200"
 },{
-  "town": "Edinburgh", 
+  "town": "Portobello", 
   "country_string": "Scotland", 
   "eastings": "330600", 
   "country": "SCT", 
@@ -8612,7 +8623,7 @@
   "latitude": "55.94686", 
   "northings": "673200"
 },{
-  "town": "Edinburgh", 
+  "town": "Liberton and Craigmillar", 
   "country_string": "Scotland", 
   "eastings": "327900", 
   "country": "SCT", 
@@ -8623,7 +8634,7 @@
   "latitude": "55.92221", 
   "northings": "670500"
 },{
-  "town": "Edinburgh", 
+  "town": "Moredun", 
   "country_string": "Scotland", 
   "eastings": "328600", 
   "country": "SCT", 
@@ -8656,7 +8667,7 @@
   "latitude": "55.87324", 
   "northings": "665000"
 },{
-  "town": "Edinburgh", 
+  "town": "New Town", 
   "country_string": "Scotland", 
   "eastings": "325400", 
   "country": "SCT", 
@@ -8777,7 +8788,7 @@
   "latitude": "55.95652", 
   "northings": "674600"
 },{
-  "town": "Edinburgh", 
+  "town": "Inverleith, New Town and Fountainbridge", 
   "country_string": "Scotland", 
   "eastings": "325100", 
   "country": "SCT", 
@@ -8898,7 +8909,7 @@
   "latitude": "56.04766", 
   "northings": "684100"
 },{
-  "town": "Edinburgh", 
+  "town": "Davidson's Mains, Barnton and Cramond", 
   "country_string": "Scotland", 
   "eastings": "321500", 
   "country": "SCT", 
@@ -9019,7 +9030,7 @@
   "latitude": "55.97656", 
   "northings": "677100"
 },{
-  "town": "Edinburgh", 
+  "town": "Granton and Trinity", 
   "country_string": "Scotland", 
   "eastings": "324100", 
   "country": "SCT", 
@@ -9085,7 +9096,7 @@
   "latitude": "55.84748", 
   "northings": "662700"
 },{
-  "town": "Edinburgh", 
+  "town": "Newhaven and Leith", 
   "country_string": "Scotland", 
   "eastings": "326700", 
   "country": "SCT", 
@@ -9096,7 +9107,7 @@
   "latitude": "55.97144", 
   "northings": "676000"
 },{
-  "town": "Edinburgh", 
+  "town": "Bonnington, Lochend and Craigentinny", 
   "country_string": "Scotland", 
   "eastings": "327300", 
   "country": "SCT", 
@@ -9107,7 +9118,7 @@
   "latitude": "55.96075", 
   "northings": "674800"
 },{
-  "town": "Edinburgh", 
+  "town": "South Bridge, Holyrood and Willowbrae", 
   "country_string": "Scotland", 
   "eastings": "327400", 
   "country": "SCT", 
@@ -9118,7 +9129,7 @@
   "latitude": "55.94909", 
   "northings": "673500"
 },{
-  "town": "Edinburgh", 
+  "town": "Marchmont and Blackford", 
   "country_string": "Scotland", 
   "eastings": "326000", 
   "country": "SCT", 
@@ -17972,6 +17983,17 @@
   "postcode": "N19", 
   "latitude": "51.56464", 
   "northings": "186800"
+},{
+  "town": "King's Cross", 
+  "country_string": "England", 
+  "eastings": "530091", 
+  "country": "ENG", 
+  "region": "Greater London", 
+  "longitude": "-0.12572", 
+  "uk_region": "London", 
+  "postcode": "N1C", 
+  "latitude": "51.53626", 
+  "northings": "183594"
 },{
   "town": "Barnet", 
   "country_string": "England", 

--- a/postcodes.csv
+++ b/postcodes.csv
@@ -739,6 +739,7 @@ E17,537300,189400,51.58623,-0.01796,Walthamstow,Greater London,London,ENG,Englan
 E18,540400,190100,51.59176,0.02705,Ilford,Greater London,London,ENG,England
 E1W,534800,180600,51.50775,-0.05739,Poplar,Greater London,London,ENG,England
 E2,534500,183000,51.52939,-0.0608,Poplar,Greater London,London,ENG,England
+E20,538350,184500,51.54593,0.09248,Queen Elizabeth Olympic Park,Greater London,London,ENG,England
 E3,537000,182900,51.52789,-0.02482,Poplar,Greater London,London,ENG,England
 E4,538200,193400,51.62196,-0.00339,Walthamstow,Greater London,London,ENG,England
 E5,535000,186300,51.55893,-0.05233,Hackney,Greater London,London,ENG,England
@@ -1633,6 +1634,7 @@ N16,533400,186700,51.5629,-0.07525,Hackney,Greater London,London,ENG,England
 N17,533600,190600,51.59791,-0.07088,Tottenham,Greater London,London,ENG,England
 N18,534000,192300,51.61309,-0.06446,Enfield,Greater London,London,ENG,England
 N19,529800,186800,51.56464,-0.12712,Islington,Greater London,London,ENG,England
+N1C,530091,183594,51.53626,-0.12572,King's Cross,Greater London,London,ENG,England
 N2,526900,189500,51.58957,-0.16797,Barnet,Greater London,London,ENG,England
 N20,526400,193900,51.62923,-0.17359,Barnet,Greater London,London,ENG,England
 N21,531600,194800,51.63612,-0.09816,Enfield,Greater London,London,ENG,England


### PR DESCRIPTION
Royal Mail have allocated some new outbound postcode areas in London:

N1C - development behind King's Cross station on former goods yard
E20 - Olympic Park